### PR TITLE
Fixes for tooltip, widget refresh, chart sizing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -424,9 +424,9 @@
       }
     },
     "@angular/flex-layout": {
-      "version": "7.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@angular/flex-layout/-/flex-layout-7.0.0-beta.23.tgz",
-      "integrity": "sha512-jH2i3i/M7SbK6scVlj2urVL5OhzwavbQ7KwvUjyc/UwccKnnzuOuWEGCINLja/aoaUO3I35LluCLv6a6VN0olA==",
+      "version": "7.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/@angular/flex-layout/-/flex-layout-7.0.0-beta.24.tgz",
+      "integrity": "sha512-ll6sK0nLGxqI/f5+z4jbd+pve1QITzgehv2AuGvfSDgIjPMeqUDB5YZqQmIGM/dQRk/vIio5KCW5LQPJWzMMYQ==",
       "requires": {
         "tslib": "^1.7.1"
       }
@@ -686,9 +686,9 @@
       }
     },
     "@swimlane/ngx-charts": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@swimlane/ngx-charts/-/ngx-charts-10.1.0.tgz",
-      "integrity": "sha512-0nZ3ub5o/qQfFMz+av89u/VKqsqiVhPFBDDOOPq2qimP83i+pcb0i3MEao7PSxIbKAEkL/pwRcEJw4KDZ8B67w==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@swimlane/ngx-charts/-/ngx-charts-11.1.0.tgz",
+      "integrity": "sha512-RdeZChfkk+ZMIyxX17S+RC5dq69Dmh3lLj+avUtjDlrUIiD8wnGyJL+RtZuHdsxtCqa0cCNydtkA5f74xl1d9g==",
       "requires": {
         "d3": "^4.10.2",
         "d3-array": "^1.2.1",
@@ -714,6 +714,16 @@
         "ng2-file-upload": "^1.3.0",
         "normalize.css": "^5.0.0",
         "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "@angular/flex-layout": {
+          "version": "7.0.0-beta.23",
+          "resolved": "https://registry.npmjs.org/@angular/flex-layout/-/flex-layout-7.0.0-beta.23.tgz",
+          "integrity": "sha512-jH2i3i/M7SbK6scVlj2urVL5OhzwavbQ7KwvUjyc/UwccKnnzuOuWEGCINLja/aoaUO3I35LluCLv6a6VN0olA==",
+          "requires": {
+            "tslib": "^1.7.1"
+          }
+        }
       }
     },
     "@types/jasmine": {
@@ -2779,9 +2789,9 @@
       "integrity": "sha1-aL+8NJM4o4DETYrMT7wzBKotjA4="
     },
     "d3-force": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.0.tgz",
-      "integrity": "sha512-PFLcDnRVANHMudbQlIB87gcfQorEsDIAvRpZ2bNddfM/WxdsEkyrEaOIPoydhH1I1V4HPjNLGOMLXCA0AuGQ9w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
+      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
       "requires": {
         "d3-collection": "1",
         "d3-dispatch": "1",
@@ -2871,9 +2881,9 @@
       "integrity": "sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg=="
     },
     "d3-shape": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.4.tgz",
-      "integrity": "sha512-izaz4fOpOnY3CD17hkZWNxbaN70sIGagLR/5jb6RS96Y+6VqX+q1BQf1av6QSBRdfULi3Gb8Js4CzG4+KAPjMg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.5.tgz",
+      "integrity": "sha512-VKazVR3phgD+MUCldapHD7P9kcrvPcexeX/PkMJmkUov4JM8IxsSg1DvbYoYich9AtdTsa5nNk2++ImPiDiSxg==",
       "requires": {
         "d3-path": "1"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/router": "~7.2.0",
     "@auth0/angular-jwt": "^2.1.0",
     "@ng-bootstrap/ng-bootstrap": "^4.0.1",
-    "@swimlane/ngx-charts": "^10.1.0",
+    "@swimlane/ngx-charts": "^11.1.0",
     "@swimlane/ngx-ui": "^25.6.0",
     "@angular/flex-layout": "^7.0.0-beta.24",
     "@types/lodash": "^4.14.123",

--- a/src/app/shared/charts/chart/chart.component.ts
+++ b/src/app/shared/charts/chart/chart.component.ts
@@ -12,6 +12,7 @@ export class ChartComponent implements OnInit {
   data: any;
   xAxisLabel: string;
   yAxisLabel: string;
+  scaleFactor: number;
 
   colorScheme: any;
 

--- a/src/app/shared/charts/combo-chart/combo-chart.component.html
+++ b/src/app/shared/charts/combo-chart/combo-chart.component.html
@@ -15,5 +15,17 @@
     [showXAxisLabel]="showXAxisLabel"
     [showYAxisLabel]="showYAxisLabel"
     [animations]='false'>
+    <ng-template #seriesTooltipTemplate let-model="model">
+      <xhtml:div class="area-tooltip-container">
+        <xhtml:div *ngFor="let tooltipItem of model" class="tooltip-item">
+          <span class="tooltip-item-color" [style.background-color]="tooltipItem.color">
+          </span>
+          {{ tooltipItem.series}}: {{ tooltipItem.value | minutes}}
+        </xhtml:div>
+      </xhtml:div>
+    </ng-template>
+    <ng-template #tooltipTemplate let-model="model">
+      Test
+    </ng-template>
   </app-line-and-bar-chart>
 </div>

--- a/src/app/shared/charts/combo-chart/combo-chart.component.html
+++ b/src/app/shared/charts/combo-chart/combo-chart.component.html
@@ -24,8 +24,5 @@
         </xhtml:div>
       </xhtml:div>
     </ng-template>
-    <ng-template #tooltipTemplate let-model="model">
-      Test
-    </ng-template>
   </app-line-and-bar-chart>
 </div>

--- a/src/app/shared/charts/combo-chart/combo-chart.component.spec.ts
+++ b/src/app/shared/charts/combo-chart/combo-chart.component.spec.ts
@@ -4,6 +4,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgxChartsModule } from '@swimlane/ngx-charts';
 import { NgxUIModule } from '@swimlane/ngx-ui';
 
+import { MinutesPipe } from '../../pipes/minutes.pipe';
 import { ComboSeriesVerticalComponent } from '../combo-series-vertical/combo-series-vertical.component';
 import { LineAndBarChartComponent } from '../line-and-bar-chart/line-and-bar-chart.component';
 import { ComboChartComponent } from './combo-chart.component';
@@ -14,7 +15,7 @@ describe('ComboChartComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ComboChartComponent, LineAndBarChartComponent, ComboSeriesVerticalComponent],
+      declarations: [ComboChartComponent, LineAndBarChartComponent, ComboSeriesVerticalComponent, MinutesPipe],
       imports: [CommonModule, NgxChartsModule, BrowserAnimationsModule, NgxUIModule]
     })
       .compileComponents();

--- a/src/app/shared/charts/line-and-bar-chart/line-and-bar-chart.component.ts
+++ b/src/app/shared/charts/line-and-bar-chart/line-and-bar-chart.component.ts
@@ -98,6 +98,7 @@ import { curveLinear } from 'd3-shape';
             [results]="combinedSeries"
             [colors]="colorsLine"
             [tooltipDisabled]="tooltipDisabled"
+            [tooltipTemplate]="seriesTooltipTemplate"
             (hover)="updateHoveredVertical($event)"
           />
 

--- a/src/app/shared/charts/number-card-chart/number-card-chart.component.ts
+++ b/src/app/shared/charts/number-card-chart/number-card-chart.component.ts
@@ -11,6 +11,7 @@ export class NumberCardChartComponent extends ChartComponent {
 
   constructor() {
     super();
+    this.scaleFactor = .85;
   }
 
   // options

--- a/src/app/shared/layouts/two-by-two-layout/two-by-two-layout.component.html
+++ b/src/app/shared/layouts/two-by-two-layout/two-by-two-layout.component.html
@@ -1,17 +1,17 @@
 <div class="container">
   <div class="row">
-    <div class="col-md-6" #chartParent>
+    <div class="col-md-8" #chartParent>
       <ng-template appChart></ng-template>
     </div>
-    <div class="col-md-6" #chartParent>
+    <div class="col-md-4" #chartParent>
       <ng-template appChart></ng-template>
     </div>
   </div>
   <div class="row">
-    <div class="col-md-6" #chartParent>
+    <div class="col-md-8" #chartParent>
       <ng-template appChart></ng-template>
     </div>
-    <div class="col-md-6" #chartParent>
+    <div class="col-md-4" #chartParent>
       <ng-template appChart></ng-template>
     </div>
   </div>

--- a/src/app/shared/layouts/two-by-two-layout/two-by-two-layout.component.ts
+++ b/src/app/shared/layouts/two-by-two-layout/two-by-two-layout.component.ts
@@ -48,7 +48,11 @@ export class TwoByTwoLayoutComponent extends LayoutComponent implements AfterVie
     const chartContainerArray = this.chartContainers.toArray();
     for (let i = 0; i < chartContainerArray.length && i < this.chartComponents.length; i++) {
       const width = chartContainerArray[i].nativeElement.getBoundingClientRect().width;
-      this.chartComponents[i].view = [width, width * .4];
+      if (this.chartComponents[i].scaleFactor) {
+        this.chartComponents[i].view = [width, width * this.chartComponents[i].scaleFactor];
+      } else {
+        this.chartComponents[i].view = [width, width * .4];
+      }
     }
     if (!(this.cdr as ViewRef).destroyed) {
       this.cdr.detectChanges();

--- a/src/app/shared/pipes/minutes.pipe.ts
+++ b/src/app/shared/pipes/minutes.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'minutes' })
+export class MinutesPipe implements PipeTransform {
+  transform(value: number): string {
+    const minutes = Math.floor(value / 60000);
+    const seconds = ((value % 60000) / 1000);
+    return (seconds === 60 ? (minutes + 1) + ':00' : minutes + ':' + (seconds < 10 ? '0' : '') + seconds.toFixed(0));
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -24,6 +24,7 @@ import { LayoutDirective } from './layouts/layout.directive';
 import { LayoutComponent } from './layouts/layout/layout.component';
 import { TwoByTwoLayoutComponent } from './layouts/two-by-two-layout/two-by-two-layout.component';
 import { PaginationComponent } from './pagination/pagination.component';
+import { MinutesPipe } from './pipes/minutes.pipe';
 import { BaseTemplateComponent } from './templates/base-template/base-template.component';
 import { TemplatesDirective } from './templates/templates.directive';
 import { PlaceholderWidgetComponent } from './widget/placeholder-widget/placeholder-widget.component';
@@ -46,6 +47,7 @@ import { WidgetDirective } from './widget/widget.directive';
     LayoutDirective,
     LineAndBarChartComponent,
     LineChartComponent,
+    MinutesPipe,
     NumberCardChartComponent,
     PaginationComponent,
     PlaceholderWidgetComponent,

--- a/src/app/shared/widget/widget.component.ts
+++ b/src/app/shared/widget/widget.component.ts
@@ -37,7 +37,7 @@ export class WidgetComponent {
 
   constructor(private componentFactoryResolver: ComponentFactoryResolver,
               private cdr: ChangeDetectorRef,
-              private dashboardService: DashboardService,
+              protected dashboardService: DashboardService,
               private route: ActivatedRoute) { }
 
 

--- a/src/app/widget_modules/build/build-widget/build-widget.component.spec.ts
+++ b/src/app/widget_modules/build/build-widget/build-widget.component.spec.ts
@@ -5,7 +5,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 import { NgbModal, NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { Observable, of, ReplaySubject } from 'rxjs';
+import { from, Observable, of, ReplaySubject } from 'rxjs';
 import { DashboardService } from 'src/app/shared/dashboard.service';
 import { SharedModule } from 'src/app/shared/shared.module';
 
@@ -278,6 +278,8 @@ class MockDashboardService {
   private dashboardSubject = new ReplaySubject<any>(1);
 
   public dashboardConfig$ = this.dashboardSubject.asObservable();
+
+  public dashboardRefresh$ = from([1, 2, 3]);
 
   loadDashboard(dashboardId: string) {
     of(GET_DASHBOARD_MOCK).subscribe(res => this.dashboardSubject.next(res));


### PR DESCRIPTION
- Allow charts to scale with their width and a different factor if needed (helps make number cards look nicer and fit better into the overall widget)
- Increase ngx-charts version to latest
- Format combo chart tooltip to show proper minutes and seconds instead of milliseconds 
- Move widget refresh interval to dashboard service so widgets always refresh together. When a widget configuration is changed it will refresh once then return to the refresh cycle.