### PR TITLE
Removing unwanted spaces from module paths

### DIFF
--- a/src/app/admin_modules/admin_dashboard/admin-dashboard-modules.ts
+++ b/src/app/admin_modules/admin_dashboard/admin-dashboard-modules.ts
@@ -29,7 +29,7 @@ import { AdminDashboardService } from './services/dashboard.service';
 import { EditDashboardComponent } from './dashboard/admin-dashboard/edit-dashboard/edit-dashboard.component';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { AuthInterceptor } from 'src/app/core/interceptors/auth.interceptor';
-import { EditDashboardModalComponent } from './dashboard/admin-dashboard/modal/edit-dashboard-modal /edit-dashboard-modal.component';
+import { EditDashboardModalComponent } from './dashboard/admin-dashboard/modal/edit-dashboard-modal/edit-dashboard-modal.component';
 
 @NgModule({
   declarations: [

--- a/src/app/admin_modules/admin_dashboard/dashboard/admin-dashboard/edit-dashboard/edit-dashboard.component.ts
+++ b/src/app/admin_modules/admin_dashboard/dashboard/admin-dashboard/edit-dashboard/edit-dashboard.component.ts
@@ -5,7 +5,7 @@ import { IPaginationParams } from 'src/app/shared/interfaces';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { DashboardItem } from '../model/dashboard-item';
 import { DeleteConfirmModalComponent } from '../../../../../shared/modals/delete-confirm-modal/delete-confirm-modal.component';
-import { EditDashboardModalComponent } from '../modal/edit-dashboard-modal /edit-dashboard-modal.component';
+import { EditDashboardModalComponent } from '../modal/edit-dashboard-modal/edit-dashboard-modal.component';
 
 @Component({
   selector: 'app-edit-dashboard',


### PR DESCRIPTION
Removing unwanted spaces from module paths, these were throwing build errors.