### PR TITLE
Getting rid of audit modal component cross click

### DIFF
--- a/src/app/shared/modals/audit-modal/audit-modal.component.html
+++ b/src/app/shared/modals/audit-modal/audit-modal.component.html
@@ -31,7 +31,4 @@
       </tbody>
     </table>
   </div>
-<div class="modal-footer">
-  <button type="button" (click)="activeModal.close('Close click')">Close</button>
-</div>
 </div>


### PR DESCRIPTION
There was an extra cross click delete in the audit modal. 