### PR TITLE
Update dashboard-list.component.scss

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_script:
 - npm install -g @angular/cli
 script:
 - ng lint
+- ng build
 - npm run test-headless
 - if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" = "master" ]; then mvn clean install -q -U; fi
 

--- a/src/app/landing_page/dashboard-list/dashboard-list.component.scss
+++ b/src/app/landing_page/dashboard-list/dashboard-list.component.scss
@@ -41,7 +41,7 @@
 
 #dSearch {
   background: #353535;
-  box-shadow: 8px 16px 6px rgb(0, 0, 0, 0.2);
+  box-shadow: 8px 16px 6px rgba(0, 0, 0, 0.2);
   color: lightgray;
 }
 


### PR DESCRIPTION
fixed the syntax error.

Getting the compilation error while running `ng build`

```
ERROR in ./src/app/landing_page/dashboard-list/dashboard-list.component.scss
Module build failed (from ./node_modules/sass-loader/lib/loader.js):

  box-shadow: 8px 16px 6px rgb(0, 0, 0, 0.2);
                          ^
      Wrong number of arguments (4 for 3) for `rgb'
      in /Users/rzheng/bb/hygieia3-ui/src/app/landing_page/dashboard-list/dashboard-list.component.scss (line 44, column 28)
```