### PR TITLE
Fix for Login Icon

### DIFF
--- a/src/app/core/navbar/navbar.component.html
+++ b/src/app/core/navbar/navbar.component.html
@@ -11,7 +11,7 @@
         <nb-user color="black" class="size-medium shape-round" name="{{userName}}"></nb-user>
       </nb-action>
       <nb-action *ngIf="isAdmin && isAuthenticated" (click)="admin()" icon="settings-outline"></nb-action>
-      <nb-action (click)="loginOrOut()" [icon]="customPowerIcon">
+      <nb-action (click)="loginOrOut()" [icon]="customPowerIcon"></nb-action>
     </nb-actions>
   </div>
 </div>

--- a/src/app/core/navbar/navbar.component.html
+++ b/src/app/core/navbar/navbar.component.html
@@ -11,8 +11,7 @@
         <nb-user color="black" class="size-medium shape-round" name="{{userName}}"></nb-user>
       </nb-action>
       <nb-action *ngIf="isAdmin && isAuthenticated" (click)="admin()" icon="settings-outline"></nb-action>
-      <nb-action (click)="loginOrOut()">
-        <nb-icon icon="power-outline" [status]="isAuthenticated? 'success' : 'danger'"></nb-icon></nb-action>
+      <nb-action (click)="loginOrOut()" [icon]="customPowerIcon">
     </nb-actions>
   </div>
 </div>

--- a/src/app/core/navbar/navbar.component.spec.ts
+++ b/src/app/core/navbar/navbar.component.spec.ts
@@ -43,4 +43,8 @@ describe('NavbarComponent', () => {
     const userTest = component.userName;
     expect(userTest).not.toBeNull();
   });
+  it('should get danger status for login icon', () => {
+    expect(component.customPowerIcon.status).toBe('danger');
+    expect(component.customPowerIcon.icon).toBe('power-outline');
+  });
 });

--- a/src/app/core/navbar/navbar.component.ts
+++ b/src/app/core/navbar/navbar.component.ts
@@ -53,4 +53,11 @@ export class NavbarComponent implements OnInit {
   openGithub() {
     window.open('https://hygieia.github.io/Hygieia/getting_started.html', '_blank');
   }
+  
+  get customPowerIcon(): NbIconConfig {
+    return {
+      icon: 'power-outline',
+      status: (this.isAuthenticated) ? 'success' : 'danger'
+    } as NbIconConfig;
+  }
 }

--- a/src/app/core/navbar/navbar.component.ts
+++ b/src/app/core/navbar/navbar.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Router } from '@angular/router';
 
+import { NbIconConfig } from '@nebular/theme';
 // local imports
 import { AuthService } from '../services/auth.service';
 @Component({

--- a/src/app/core/navbar/navbar.component.ts
+++ b/src/app/core/navbar/navbar.component.ts
@@ -54,7 +54,6 @@ export class NavbarComponent implements OnInit {
   openGithub() {
     window.open('https://hygieia.github.io/Hygieia/getting_started.html', '_blank');
   }
-  
   get customPowerIcon(): NbIconConfig {
     return {
       icon: 'power-outline',


### PR DESCRIPTION
Users can now use tab to navigate to the login Icon
Users will now see the correct pointer when hovering the login Icon 